### PR TITLE
Fixed inversion of the synctex parameter in latexmk-based rules

### DIFF
--- a/rules/lualatexmk.yaml
+++ b/rules/lualatexmk.yaml
@@ -11,7 +11,7 @@ arguments:
 - identifier: shell
   flag: <arara> @{isTrue(parameters.shell,"--shell-escape"," --no-shell-escape")}
 - identifier: synctex
-  flag: <arara> @{isTrue(parameters.synctex,"--synctex=0","--synctex=1")}
+  flag: <arara> @{isTrue(parameters.synctex,"--synctex=1","--synctex=0")}
 - identifier: options
   flag: <arara> @{parameters.options}
 - identifier: style

--- a/rules/pdflatexmk.yaml
+++ b/rules/pdflatexmk.yaml
@@ -11,7 +11,7 @@ arguments:
 - identifier: shell
   flag: <arara> @{isTrue(parameters.shell,"--shell-escape"," --no-shell-escape")}
 - identifier: synctex
-  flag: <arara> @{isTrue(parameters.synctex,"--synctex=0","--synctex=1")}
+  flag: <arara> @{isTrue(parameters.synctex,"--synctex=1","--synctex=0")}
 - identifier: options
   flag: <arara> @{parameters.options}
 - identifier: style

--- a/rules/xelatexmk.yaml
+++ b/rules/xelatexmk.yaml
@@ -11,7 +11,7 @@ arguments:
 - identifier: shell
   flag: <arara> @{isTrue(parameters.shell,"--shell-escape"," --no-shell-escape")}
 - identifier: synctex
-  flag: <arara> @{isTrue(parameters.synctex,"--synctex=0","--synctex=1")}
+  flag: <arara> @{isTrue(parameters.synctex,"--synctex=1","--synctex=0")}
 - identifier: options
   flag: <arara> @{parameters.options}
 - identifier: style


### PR DESCRIPTION
I guess this typo was introduced during a cleanup...
