### PR TITLE
Added initial TikZ list-and-make rule.

### DIFF
--- a/rules/tikzmake.yaml
+++ b/rules/tikzmake.yaml
@@ -1,0 +1,34 @@
+!config
+# Arara, the cool TeX automation tool
+# Copyright (c) 2012, Paulo Roberto Massa Cereda 
+# All rights reserved.
+#
+# This rule is part of arara.
+identifier: tikzmake
+name: TikZmake
+authors:
+- Robbie Smith
+- Paulo Cereda
+commands:
+- name: TikZ list-and-make engine
+  command: >
+    @{
+        makefile = getBasename(file).concat('.makefile');
+        return getCommand('make', force, options, '-f', makefile);
+    }
+arguments:
+- identifier: force
+  flag: >
+    @{
+        isTrue(parameters.force, '--always-make')
+    }
+- identifier: options
+  flag: >
+    @{
+        if (isList(parameters.options)) {
+            return parameters.options;
+        }
+        else {
+            throwError('I was expecting a list of options.')
+        }
+    }


### PR DESCRIPTION
This is a basic rule that allows the use of the TikZ `external/mode=list and make` setting. TikZ creates a makefile called `\jobname.makefile`, and this rule will ensure that make gets called on the correct file. I haven't tested it with anything other than a Linux system, and there are probably improvements to make, but it does the job.